### PR TITLE
FFWEB-1722: Makes NG module compatible with base module in version 1.6.1

### DIFF
--- a/src/etc/adminhtml/system.xml
+++ b/src/etc/adminhtml/system.xml
@@ -5,16 +5,14 @@
             <group id="general">
                 <field id="authentication_prefix">
                     <depends>
-                        <field negative="1" id="factfinder/advanced/version">ng</field>
+                        <field negative="1" id="factfinder/general/version">ng</field>
                     </depends>
                 </field>
                 <field id="authentication_postfix">
                     <depends>
-                        <field negative="1" id="factfinder/advanced/version">ng</field>
+                        <field negative="1" id="factfinder/general/version">ng</field>
                     </depends>
                 </field>
-            </group>
-            <group id="advanced">
                 <field id="version">
                     <options>
                         <option label="NG">ng</option>


### PR DESCRIPTION
adjust system.xml to be compatible with v1.6.1 of magento2 module