### PR TITLE
Correctly handle tracking requests

### DIFF
--- a/src/Model/Client.php
+++ b/src/Model/Client.php
@@ -14,6 +14,8 @@ use Omikron\FactfinderNG\Model\Api\CredentialsFactory;
 
 class Client implements ApiClientInterface
 {
+    private const TRACKING_RESPONSE_SUCCESS = 'OK';
+
     /** @var ClientFactory */
     private $httpClientFactory;
 
@@ -60,7 +62,7 @@ class Client implements ApiClientInterface
             }
 
             if ($httpClient->getStatus() == 200) {
-                if ($httpClient->getBody()) {
+                if ($httpClient->getBody() && $httpClient->getBody() !== self::TRACKING_RESPONSE_SUCCESS) {
                     return (array) $this->serializer->unserialize($httpClient->getBody());
                 } else {
                     return $httpClient->getHeaders();


### PR DESCRIPTION
On v3 tracking requests, the FACT-Finder servers responds with "OK", which is not a valid JSON response. In this case, the JSON serializer would raise an error. Introduce a dedicated handling to prevent errors.